### PR TITLE
allow array syntax for hostname

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,9 +59,11 @@ export default class RabbotClient extends EventEmitter {
     assert(opts.username, 'configured-rabbitmq-client missing username setting');
     assert(opts.password, 'configured-rabbitmq-client missing password setting');
 
+    const hostname = Array.isArray(opts.hostname) ? opts.hostname.join(',') : opts.hostname;
+
     context.logger.info('Initializing RabbitMQ client', {
       user: opts.username,
-      host: opts.hostname || 'rabbitmq',
+      host: hostname || 'rabbitmq',
     });
     const mqConnectionConfig = {
       // In our usage, we've found that a short timeout causes trouble
@@ -71,7 +73,7 @@ export default class RabbotClient extends EventEmitter {
       ...opts.connectionOptions,
       user: opts.username,
       pass: opts.password,
-      host: opts.hostname || 'rabbitmq',
+      host: hostname || 'rabbitmq',
       port: opts.port || 5672,
       vhost: opts.basePath || '/',
     };

--- a/tests/test_connection.js
+++ b/tests/test_connection.js
@@ -47,3 +47,12 @@ tap.test('test_connection', async (t) => {
   await mq.stop(ctx);
   t.ok(true, 'Should shut down');
 });
+
+tap.test('test_connection with array hostname', async (t) => {
+  const config = { ...mqConfig, hostname: [mqConfig.hostname, mqConfig.hostname] };
+  const mq = new RabbotClient(ctx, config);
+  const client = await mq.start(ctx);
+  t.ok(client.publish, 'Should have a publish method');
+  await mq.stop(ctx);
+  t.ok(true, 'Should shut down');
+});


### PR DESCRIPTION
will enable us to use the dns shortstop handler (already in service) to use multiple A records