### PR TITLE
[CS-1569] Support perMessageTtl for retry queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,18 @@ exchanges and queues are `durable` by default. You can make messages persistent 
 
  Follow [this link](https://github.com/gas-buddy/wiki/wiki/Persistent-rabbitMQ-messages) to see more options
 
+## TTL
+Only retry queue use TTL by default. You can set it by doing the following.
+
+NOTE: **You cannot change TTL on an existing queue**.
+```
+{
+  "exchangeGroups": {
+    "exchange.test.request.v1": {
+      ...
+      "perMessageTtl": true, // It should be used on new exchange groups even if you don't change the default value
+      "retryDelay": 60000, // default 10000ms
+    }
+  }
+}
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gasbuddy/configured-rabbitmq-client",
-  "version": "8.0.2",
+  "version": "8.1.0",
   "description": "A configuration driven RabbitMQ client",
   "main": "build/index.js",
   "scripts": {

--- a/src/exchangeGroups.js
+++ b/src/exchangeGroups.js
@@ -43,9 +43,9 @@ function normalizeExchangeGroup(key, group) {
   normalized.queue = groupFromInput(group.queue, { name: `${exchangeName}.q` });
 
   if (normalized.retries) {
-    const [suffix, ttlKey] = group.perMessageTtl === true ? ['.nottl', 'perMessageTtl'] : ['', 'messageTtl'];
-    normalized.retryExchange = groupFromInput(group.retryExchange, { name: `${exchangeName}${suffix}.retry`, persistent });
+    normalized.retryExchange = groupFromInput(group.retryExchange, { name: `${exchangeName}.retry`, persistent });
     normalized.retryQueue = groupFromInput(group.retryQueue, { name: `${normalized.retryExchange.name}.q` });
+    const ttlKey = group.perMessageTtl === true ? 'perMessageTtl' : 'messageTtl';
     normalized.retryQueue[ttlKey] = normalized.retryDelay;
   }
 

--- a/src/exchangeGroups.js
+++ b/src/exchangeGroups.js
@@ -54,7 +54,6 @@ function normalizeExchangeGroup(key, group) {
     normalized.rejectedQueue = groupFromInput(group.rejectedQueue, { name: `${normalized.rejectedExchange.name}.q` });
   }
 
-
   return normalized;
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -295,6 +295,7 @@ the MQ_MAKE_EXCHANGES environment variable and restart.
                 routingKey: message.fields.routingKey,
                 correlationId: message.properties.correlationId,
                 timestamp: message.properties.timestamp,
+                expiresAfter: exchangeGroup.retryQueue.perMessageTtl || undefined,
                 headers,
               };
               await this.publish(exchangeGroup.retryExchange.name, messageOptions);

--- a/tests/test_config.js
+++ b/tests/test_config.js
@@ -169,6 +169,5 @@ tap.test('test delivery_mode pass thru', async (t) => {
     await mq.publish('persistent', 'one', {});
   });
   t.equal(RabbotClient.activeMessages.size, 0, 'Should have 0 active message');
-  await bluebird.delay(1000);
   await mq.stop(ctx);
 });

--- a/tests/test_exchange_groups.js
+++ b/tests/test_exchange_groups.js
@@ -28,11 +28,17 @@ const rejectedOnlyCase = {
   keys: 'rejectedonlykey',
 };
 
+const perMessageTtl = {
+  perMessageTtl: true,
+  keys: 'somekey',
+};
+
 const exchangeGroups = {
   simpleCase,
   noRetryCase,
   complexCase,
   rejectedOnlyCase,
+  perMessageTtl,
 };
 
 
@@ -56,6 +62,7 @@ tap.test('test exchange group normalization', async (t) => {
   t.ok(finalGroups.complexCase.queue.name === complexCase.queue.name, 'Deep queue name is accepted');
   t.ok(finalGroups.complexCase.queue.autoDelete === complexCase.queue.autoDelete, 'Deep queue properties are accepted');
   t.ok(finalGroups.complexCase.retryQueue.name === complexCase.retryQueue, 'Additional queue overrides are accepted.');
+  t.ok(finalGroups.complexCase.retryQueue.messageTtl === complexCase.retryDelay, 'messageTtl should match retryDelay on retry queue');
 
   t.ok(finalGroups.rejectedOnlyCase.exchange
        && finalGroups.rejectedOnlyCase.queue
@@ -63,6 +70,9 @@ tap.test('test exchange group normalization', async (t) => {
        && !finalGroups.rejectedOnlyCase.retryQueue
        && finalGroups.rejectedOnlyCase.rejectedExchange
        && finalGroups.rejectedOnlyCase.rejectedQueue && 'Rejected queue should be generated when specified with zero retries');
+
+  t.ok(finalGroups.perMessageTtl.retryQueue.messageTtl === undefined, 'retryQueue messageTtl should be undefined when perMessageTtl is requested');
+  t.ok(finalGroups.perMessageTtl.retryQueue.name.indexOf('nottl') > 0, 'Retry queue should have "pmttl" in name when perMessageTtl is requested');
 });
 
 tap.test('test exchange group to rabbot config translation', async (t) => {

--- a/tests/test_exchange_groups.js
+++ b/tests/test_exchange_groups.js
@@ -71,8 +71,8 @@ tap.test('test exchange group normalization', async (t) => {
        && finalGroups.rejectedOnlyCase.rejectedExchange
        && finalGroups.rejectedOnlyCase.rejectedQueue && 'Rejected queue should be generated when specified with zero retries');
 
-  t.ok(finalGroups.perMessageTtl.retryQueue.messageTtl === undefined, 'retryQueue messageTtl should be undefined when perMessageTtl is requested');
-  t.ok(finalGroups.perMessageTtl.retryQueue.name.indexOf('nottl') > 0, 'Retry queue should have "pmttl" in name when perMessageTtl is requested');
+  t.ok(finalGroups.perMessageTtl.retryQueue.messageTtl === undefined, 'retryQueue messageTtl should be undefined when perMessageTtl is set');
+  t.ok(finalGroups.perMessageTtl.retryQueue.name.indexOf('nottl') > 0, 'Retry queue should have "nottl" in name when perMessageTtl is set');
 });
 
 tap.test('test exchange group to rabbot config translation', async (t) => {

--- a/tests/test_exchange_groups.js
+++ b/tests/test_exchange_groups.js
@@ -72,7 +72,6 @@ tap.test('test exchange group normalization', async (t) => {
        && finalGroups.rejectedOnlyCase.rejectedQueue && 'Rejected queue should be generated when specified with zero retries');
 
   t.ok(finalGroups.perMessageTtl.retryQueue.messageTtl === undefined, 'retryQueue messageTtl should be undefined when perMessageTtl is set');
-  t.ok(finalGroups.perMessageTtl.retryQueue.name.indexOf('nottl') > 0, 'Retry queue should have "nottl" in name when perMessageTtl is set');
 });
 
 tap.test('test exchange group to rabbot config translation', async (t) => {


### PR DESCRIPTION
**Problem:**
We cannot change `messageTtl` on a queue

**Proposed Solution:**
Don't set  message TTL on queue, set it on per message basis

**Implementation:**
To enable per message TTL on a new exchange, do:
```
{
...
perMessageTtl: true,
}
```
https://github.com/gas-buddy/configured-rabbitmq-client/pull/41/files#diff-9a2ef05db639148d956ff61a1331ad1aR48
- `messageTtl` is for rabbot to set on queue.
- `perMessageTtl` is for this client to set it on per message.